### PR TITLE
Use in memory buffer for rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,3 @@ atelier-core = { version = "0.1", path = "core" }
 atelier-daemon = { version = "0.1", path = "daemon" }
 atelier-importer = { version = "0.1", path = "importer" }
 atelier-loader = { version = "0.1", path = "loader" }
-

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+atelier-core = { path = "../core" }
 capnp = "0.12"
 capnp-rpc = "0.12"
 tokio = { version = "0.2", features = ["io-std", "rt-util", "tcp", "io-util"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,6 @@ tokio-util = { version = "0.2", features = ["codec"] }
 futures = "0.3"
 atelier-schema = { path = "../schema" }
 uuid = "0.8"
-futures-tokio-compat = { git = "https://github.com/dwrensha/futures-tokio-compat", branch = "tokio-0.2" }
 async-trait = "0.1.22"
 crossterm = { version = "0.14.2", features = ["event-stream"] }
 defer = "0.1.0"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,7 +65,6 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "127.0.0.1:9999".to_socket_addrs()?.next().unwrap();
     let stream = tokio::net::TcpStream::connect(&addr).await?;
     stream.set_nodelay(true).unwrap();
-    // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
     let (writer, reader) = utils::async_channel();
     let rpc_network = Box::new(twoparty::VatNetwork::new(
         reader,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,7 +65,7 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "127.0.0.1:9999".to_socket_addrs()?.next().unwrap();
     let stream = tokio::net::TcpStream::connect(&addr).await?;
     stream.set_nodelay(true).unwrap();
-    let (writer, reader) = utils::async_channel();
+    let (writer, reader) = utils::async_channel(stream);
     let rpc_network = Box::new(twoparty::VatNetwork::new(
         reader,
         writer,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,10 +7,10 @@ use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
 use capnp::message::ReaderOptions;
 
 use async_trait::async_trait;
-use futures::AsyncReadExt;
 use std::{cell::RefCell, rc::Rc, time::Instant};
 use tokio::runtime::Runtime;
 
+use atelier_core::utils;
 mod shell;
 use shell::{Autocomplete, Command, Shell};
 
@@ -65,7 +65,8 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "127.0.0.1:9999".to_socket_addrs()?.next().unwrap();
     let stream = tokio::net::TcpStream::connect(&addr).await?;
     stream.set_nodelay(true).unwrap();
-    let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+    // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+    let (writer, reader) = utils::async_channel();
     let rpc_network = Box::new(twoparty::VatNetwork::new(
         reader,
         writer,

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,4 +10,3 @@ capnp-rpc = "0.12"
 tokio = "0.2"
 futures = "0.3"
 atelier-schema = { path = "../schema" }
-futures-tokio-compat = { git = "https://github.com/dwrensha/futures-tokio-compat", branch = "tokio-0.2", optional = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+atelier-core = { path = "../core" }
 capnp = "0.12"
 capnp-rpc = "0.12"
 tokio = "0.2"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -34,7 +34,7 @@ pub fn main() {
             stream.set_send_buffer_size(1 << 24).unwrap();
             stream.set_recv_buffer_size(1 << 24).unwrap();
             use futures::AsyncReadExt;
-            let (writer, reader) = utils::async_channel();
+            let (writer, reader) = utils::async_channel(stream);
             let rpc_network = Box::new(twoparty::VatNetwork::new(
                 reader,
                 writer,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,6 +4,7 @@ use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
 use capnp::message::ReaderOptions;
 
+use atelier_core::utils;
 use futures::Future;
 use std::{
     sync::atomic::{AtomicUsize, Ordering},
@@ -33,7 +34,8 @@ pub fn main() {
             stream.set_send_buffer_size(1 << 24).unwrap();
             stream.set_recv_buffer_size(1 << 24).unwrap();
             use futures::AsyncReadExt;
-            let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+            // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+            let (writer, reader) = utils::async_channel();
             let rpc_network = Box::new(twoparty::VatNetwork::new(
                 reader,
                 writer,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -34,7 +34,6 @@ pub fn main() {
             stream.set_send_buffer_size(1 << 24).unwrap();
             stream.set_recv_buffer_size(1 << 24).unwrap();
             use futures::AsyncReadExt;
-            // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
             let (writer, reader) = utils::async_channel();
             let rpc_network = Box::new(twoparty::VatNetwork::new(
                 reader,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro-hack = "0.5"
 asset-uuid = { path = "./asset-uuid" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 inventory = { version = "0.1", optional = true }
+futures = "0.3"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [features]
 serde-1 = ["serde"]
 importer_context = ["inventory"]
+futures-tokio-compat-1 = ["futures-tokio-compat"]
 
 [dependencies]
 uuid = { version = "0.8", features = [ "v4" ] }
@@ -14,6 +15,7 @@ asset-uuid = { path = "./asset-uuid" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 inventory = { version = "0.1", optional = true }
 futures = "0.3"
+futures-tokio-compat = { git = "https://github.com/dwrensha/futures-tokio-compat", branch = "tokio-0.2", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [features]
 serde-1 = ["serde"]
 importer_context = ["inventory"]
-futures-tokio-compat-1 = ["futures-tokio-compat"]
+futures-tokio-compat-1 = ["futures-util", "futures-tokio-compat"]
 
 [dependencies]
 uuid = { version = "0.8", features = [ "v4" ] }
@@ -15,7 +15,9 @@ asset-uuid = { path = "./asset-uuid" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 inventory = { version = "0.1", optional = true }
 futures = "0.3"
+futures-util = { version = "0.3.4", optional = true }
 futures-tokio-compat = { git = "https://github.com/dwrensha/futures-tokio-compat", branch = "tokio-0.2", optional = true }
+tokio = { version = "0.2", features = ["tcp", "sync", "rt-core", "rt-util", "stream"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -5,6 +5,15 @@ use std::{
     path::PathBuf,
 };
 
+use core::pin::Pin;
+use core::task::Context;
+use core::task::Poll;
+
+use futures::{AsyncRead, AsyncWrite};
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
 pub fn make_array<A, T>(slice: &[T]) -> A
 where
     A: Sized + Default + AsMut<[T]>,
@@ -47,4 +56,96 @@ where
         dep.hash(&mut hasher);
     }
     hasher.finish()
+}
+
+pub struct AsyncSender {
+    pub buf: Arc<Mutex<VecDeque<u8>>>,
+}
+
+impl AsyncSender {
+    fn new() -> Self {
+        Self {
+            buf: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+}
+
+impl AsyncWrite for AsyncSender {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        let mut guard = self.get_mut().buf.lock().unwrap();
+        let mut buf: VecDeque<u8> = buf.to_vec().into_iter().collect();
+        let n = buf.len();
+        guard.append(&mut buf);
+
+        match n {
+            0 => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            _ => Poll::Ready(Ok(n)),
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+pub struct AsyncReceiver {
+    buf: Arc<Mutex<VecDeque<u8>>>,
+}
+
+impl AsyncReceiver {
+    fn new() -> Self {
+        Self {
+            buf: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+}
+
+impl AsyncRead for AsyncReceiver {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        let mut guard = self.get_mut().buf.lock().unwrap();
+        let mut n = 0;
+
+        for i in 0..buf.len() {
+            match guard.pop_front() {
+                Some(byte) => {
+                    buf[i] = byte;
+                    n += 1;
+                }
+                None => break,
+            }
+        }
+
+        match n {
+            0 => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            _ => Poll::Ready(Ok(n)),
+        }
+    }
+}
+
+pub fn async_channel() -> (AsyncSender, AsyncReceiver) {
+    (AsyncSender::new(), AsyncReceiver::new())
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -146,6 +146,12 @@ impl AsyncRead for AsyncReceiver {
     }
 }
 
+#[cfg(feature = "futures-tokio-compat-1")]
+pub fn async_channel() -> (AsyncSender, AsyncReceiver) {
+    futures_tokio_compat::Compat::new(stream).split()
+}
+
+#[cfg(not(feature = "futures-tokio-compat-1"))]
 pub fn async_channel() -> (AsyncSender, AsyncReceiver) {
     (AsyncSender::new(), AsyncReceiver::new())
 }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -19,7 +19,6 @@ fern = "0.5"
 log = { version = "0.4", features = ["serde"] }
 tokio = { version = "0.2", features = ["tcp", "sync", "rt-core", "rt-util", "stream"] }
 futures = "0.3"
-futures-tokio-compat = { git = "https://github.com/dwrensha/futures-tokio-compat", branch = "tokio-0.2" }
 owning_ref = "0.4"
 crossbeam-channel = "0.3"
 mopa = "0.2.2"

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -474,7 +474,6 @@ impl AssetHubService {
                     stream.set_nodelay(true).unwrap();
                     stream.set_send_buffer_size(1 << 22).unwrap();
                     stream.set_recv_buffer_size(1 << 22).unwrap();
-                    // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
                     let (writer, reader) = utils::async_channel();
                     spawn_rpc(reader, writer, self.ctx.clone());
                 }

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -474,7 +474,7 @@ impl AssetHubService {
                     stream.set_nodelay(true).unwrap();
                     stream.set_send_buffer_size(1 << 22).unwrap();
                     stream.set_recv_buffer_size(1 << 22).unwrap();
-                    let (writer, reader) = utils::async_channel();
+                    let (writer, reader) = utils::async_channel(stream);
                     spawn_rpc(reader, writer, self.ctx.clone());
                 }
             });

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -18,8 +18,7 @@ use atelier_schema::{
 };
 use capnp;
 use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
-
-use futures::{AsyncReadExt, TryFutureExt};
+use futures::TryFutureExt;
 use owning_ref::OwningHandle;
 use std::{
     collections::{HashMap, HashSet},
@@ -38,7 +37,7 @@ struct ServiceContext {
     hub: Arc<AssetHub>,
     file_source: Arc<FileAssetSource>,
     file_tracker: Arc<FileTracker>,
-    artifact_cache: Arc<ArtifactCache>,
+    _artifact_cache: Arc<ArtifactCache>,
     db: Arc<Environment>,
 }
 
@@ -406,13 +405,14 @@ impl AssetHubImpl {
     }
 }
 
-fn endpoint() -> String {
+fn _endpoint() -> String {
     if cfg!(windows) {
         r"\\.\pipe\atelier-assets".to_string()
     } else {
         r"/tmp/atelier-assets".to_string()
     }
 }
+
 fn spawn_rpc<
     R: std::marker::Unpin + futures::AsyncRead + Send + 'static,
     W: std::marker::Unpin + futures::AsyncWrite + Send + 'static,
@@ -454,7 +454,7 @@ impl AssetHubService {
                 db,
                 file_source,
                 file_tracker,
-                artifact_cache,
+                _artifact_cache: artifact_cache,
             }),
         }
     }
@@ -474,7 +474,8 @@ impl AssetHubService {
                     stream.set_nodelay(true).unwrap();
                     stream.set_send_buffer_size(1 << 22).unwrap();
                     stream.set_recv_buffer_size(1 << 22).unwrap();
-                    let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+                    // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+                    let (writer, reader) = utils::async_channel();
                     spawn_rpc(reader, writer, self.ctx.clone());
                 }
             });

--- a/examples/daemon_with_loader/src/main.rs
+++ b/examples/daemon_with_loader/src/main.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 mod daemon;
 mod game;
 mod image;

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -27,7 +27,6 @@ atelier-importer = { path = "../importer" }
 uuid = { version = "0.8", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }
 
-
 [features]
 default = ["rpc_loader", "handle"]
 rpc_loader = ["atelier-schema", "tokio", "capnp", "capnp-rpc", "futures", "log", "dashmap"]

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -20,7 +20,6 @@ derivative = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}
 inventory = { version = "0.1", optional = true }
 uuid = { version = "0.8", optional = true }
-futures-tokio-compat = { git = "https://github.com/dwrensha/futures-tokio-compat", branch = "tokio-0.2", optional = true }
 
 [dev-dependencies]
 atelier-daemon = { path = "../daemon" }
@@ -31,5 +30,5 @@ serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = ["rpc_loader", "handle"]
-rpc_loader = ["atelier-schema", "tokio", "capnp", "capnp-rpc", "futures", "log", "dashmap", "futures-tokio-compat"]
+rpc_loader = ["atelier-schema", "tokio", "capnp", "capnp-rpc", "futures", "log", "dashmap"]
 handle = ["derivative", "serde", "inventory", "uuid"]

--- a/loader/src/rpc_state.rs
+++ b/loader/src/rpc_state.rs
@@ -198,7 +198,7 @@ impl RpcState {
                     .await
                     .map_err(|e| -> Box<dyn Error> { Box::new(e) })?;
                 stream.set_nodelay(true)?;
-                let (writer, reader) = utils::async_channel();
+                let (writer, reader) = utils::async_channel(stream);
                 let rpc_network = Box::new(twoparty::VatNetwork::new(
                     reader,
                     writer,

--- a/loader/src/rpc_state.rs
+++ b/loader/src/rpc_state.rs
@@ -198,8 +198,8 @@ impl RpcState {
                     .await
                     .map_err(|e| -> Box<dyn Error> { Box::new(e) })?;
                 stream.set_nodelay(true)?;
-                use futures::AsyncReadExt;
-                let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+                // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
+                let (writer, reader) = utils::async_channel();
                 let rpc_network = Box::new(twoparty::VatNetwork::new(
                     reader,
                     writer,

--- a/loader/src/rpc_state.rs
+++ b/loader/src/rpc_state.rs
@@ -198,7 +198,6 @@ impl RpcState {
                     .await
                     .map_err(|e| -> Box<dyn Error> { Box::new(e) })?;
                 stream.set_nodelay(true)?;
-                // let (reader, writer) = futures_tokio_compat::Compat::new(stream).split();
                 let (writer, reader) = utils::async_channel();
                 let rpc_network = Box::new(twoparty::VatNetwork::new(
                     reader,


### PR DESCRIPTION
Issue https://github.com/amethyst/atelier-assets/issues/43

### Major

- Provides an alternative communication buffer to `futures_tokio_compat`

### Minor

- Cleans up some warnings

### Notes

- `.meta` keys output order change observed