### PR TITLE
Pin exact dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ members = [
 ]
 
 [dependencies]
-distill-core = { version = "0.0.3", path = "core" }
-distill-daemon = { version = "0.0.3", path = "daemon" }
-distill-importer = { version = "0.0.3", path = "importer" }
-distill-loader = { version = "0.0.3", path = "loader" }
+distill-core = { version = "=0.0.3", path = "core" }
+distill-daemon = { version = "=0.0.3", path = "daemon" }
+distill-importer = { version = "=0.0.3", path = "importer" }
+distill-loader = { version = "=0.0.3", path = "loader" }
 
 [dev-dependencies]
 futures = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distill-cli"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Karl Bergström <karl.anton.bergstrom@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -8,12 +8,13 @@ description = "CLI component of `distill`."
 publish = false
 
 [dependencies]
+distill-schema = { version = "=0.0.3", path = "../schema" }
+
 capnp = "0.14.0"
 capnp-rpc = "0.14.0"
 tokio = { version = "1.2", features = ["io-std", "rt", "rt-multi-thread", "net", "io-util"] }
 tokio-util = { version = "0.6.1", features = ["codec", "compat"] }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-distill-schema = { version = "0.0.3", path = "../schema" }
 uuid = "0.8.2"
 async-trait = "0.1.22"
 crossterm = { version = "0.17", features = ["event-stream"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,9 +7,10 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
+distill-schema = { path = "../schema" }
+
 capnp = "0.14.0"
 capnp-rpc = "0.14.0"
 tokio = "1.2"
 tokio-util = { version = "0.6.1", features = ["compat"] }
 futures-util = { version = "0.3", default-features = false }
-distill-schema = { path = "../schema" }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -7,10 +7,10 @@ license = "MIT OR Apache-2.0"
 description = "Daemon component of the asset pipeline `distill`."
 
 [dependencies]
-distill-core = { path = "../core", version = "0.0.3", features = ["path_utils"] }
-distill-schema = { path = "../schema", version = "0.0.3" }
-distill-importer = { path = "../importer", version = "0.0.3" }
-distill-loader = { path = "../loader", version = "0.0.3" }
+distill-core = { path = "../core", version = "=0.0.3", features = ["path_utils"] }
+distill-schema = { path = "../schema", version = "=0.0.3" }
+distill-importer = { path = "../importer", version = "=0.0.3" }
+distill-loader = { path = "../loader", version = "=0.0.3" }
 dunce = "1.0"
 path-clean = "0.1"
 path-slash = "0.1.1"

--- a/examples/daemon_with_loader/Cargo.toml
+++ b/examples/daemon_with_loader/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 publish = false
 
 [dependencies]
-distill = { version = "0.0.3", path = "../../", features = ["type_uuid"] }
+distill = { version = "=0.0.3", path = "../../", features = ["type_uuid"] }
 image2 = { version = "0.11", features = ["ser"] }
 log = { version = "0.4", features = ["serde"] }
 serde = "1"

--- a/examples/handle_integration/Cargo.toml
+++ b/examples/handle_integration/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 publish = false
 
 [dependencies]
-distill = { version = "0.0.3", path = "../..", features = ["serde_importers", "pretty_log"] }
+distill = { version = "=0.0.3", path = "../..", features = ["serde_importers", "pretty_log"] }
 futures-executor = { version = "0.3", default-features = false }
 tokio = { version = "1.2", features = ["io-util"] }
 

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -7,13 +7,14 @@ license = "MIT OR Apache-2.0"
 description = "Importer component of the asset pipeline `distill`."
 
 [dependencies]
-distill-core = { path = "../core", version = "0.0.3", features = ["serde-1"] }
+distill-core = { path = "../core", version = "=0.0.3", features = ["serde-1"] }
+distill-serde-importable-derive = { path = "./serde-importable-derive", version = "=0.0.3", optional = true }
+
 uuid = { version = "0.8.2", features = ["v4"] }
 serde = "1"
 erased-serde = "0.3"
 ron = { version = "0.6.4", optional = true }
 typetag = { version = "0.1", optional = true }
-distill-serde-importable-derive = { path = "./serde-importable-derive", version = "0.0.3", optional = true }
 futures = "0.3"
 log = { version = "0.4", features = ["serde"] }
 

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -7,9 +7,10 @@ license = "MIT OR Apache-2.0"
 description = "Loader component of the asset pipeline `distill`."
 
 [dependencies]
+distill-core = { path = "../core", version = "=0.0.3", features = ["serde-1"] }
+distill-schema = { path = "../schema", version = "=0.0.3", optional = true }
+
 crossbeam-channel = "0.5.0"
-distill-core = { path = "../core", version = "0.0.3", features = ["serde-1"] }
-distill-schema = { path = "../schema", version = "0.0.3", optional = true }
 tokio = { version = "1.2", features = ["net", "sync", "rt", "rt-multi-thread"], optional = true }
 tokio-util = { version = "0.6.1", features = ["compat"], optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["io"], optional = true }
@@ -23,7 +24,6 @@ serde = { version = "1", features = ["derive"], optional = true }
 uuid = { version = "0.8.2", optional = true }
 memmap = { version = "0.7", optional = true }
 thread_local = { version = "1.0", optional = true }
-
 
 [features]
 default = ["rpc_io", "handle", "packfile_io"]

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -7,5 +7,6 @@ license = "MIT OR Apache-2.0"
 description = "RPC schema definitions for the asset pipeline `distill`."
 
 [dependencies]
+distill-core = { path = "../core", version = "=0.0.3" }
+
 capnp = "0.14.0"
-distill-core = { path = "../core", version = "0.0.3" }


### PR DESCRIPTION
Pin exact dependency versions since we aren't using semver yet.
Group in-tree distill dependencies together in Cargo.toml

There are some whitespace changes in here that are not *necessary* but may make it a tiny bit easier to bump these numbers all at once.
