### PR TITLE
Remove futures crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ distill-importer = { version = "=0.0.3", path = "importer", optional = true }
 distill-loader = { version = "=0.0.3", path = "loader", optional = true }
 
 [dev-dependencies]
-futures = "0.3"
+futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-io = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 serde = "1"
 uuid = "0.8.2"
 serial_test = "0.5.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ distill-schema = { version = "=0.0.3", path = "../schema" }
 
 capnp = "0.14.0"
 capnp-rpc = "0.14.0"
-futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+futures-util = { version = "0.3", default-features = false }
 uuid = "0.8.2"
 async-trait = "0.1.22"
 crossterm = { version = "0.17", features = ["event-stream"] }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,7 +9,7 @@ use distill_schema::{
 };
 
 pub mod shell;
-use futures::AsyncReadExt;
+use futures_util::AsyncReadExt;
 use shell::Autocomplete;
 pub use shell::Command;
 

--- a/cli/src/shell.rs
+++ b/cli/src/shell.rs
@@ -8,7 +8,7 @@ use crossterm::{
     style::{Color, Print, ResetColor, SetBackgroundColor, SetForegroundColor},
     terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
 };
-use futures::{
+use futures_util::{
     future::{pending, FusedFuture, FutureExt},
     select,
     stream::StreamExt,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ path_utils = ["dunce", "path-clean", "path-slash"]
 uuid = { version = "0.8.2", features = ["v4"] }
 serde = { version = "1", optional = true, features = ["derive"] }
 futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
-futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+futures-channel = { version = "0.3", default-features = false, features = ["std"] }
 type-uuid = { version = "0.1.2", optional = true, default-features = false }
 dunce = { version = "1.0", optional = true }
 path-clean = { version = "0.1", optional = true }

--- a/core/src/distill_signal.rs
+++ b/core/src/distill_signal.rs
@@ -2,20 +2,20 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// Thin wrapper around `futures::channel::oneshot` to match `tokio::sync::oneshot` interface.
+/// Thin wrapper around `futures_channel::oneshot` to match `tokio::sync::oneshot` interface.
 pub fn oneshot<T>() -> (Sender<T>, Receiver<T>) {
-    let (sender, receiver) = futures::channel::oneshot::channel();
+    let (sender, receiver) = futures_channel::oneshot::channel();
     (Sender::new(sender), Receiver::new(receiver))
 }
 
 #[derive(Debug)]
 pub struct Receiver<T> {
-    inner: futures::channel::oneshot::Receiver<T>,
+    inner: futures_channel::oneshot::Receiver<T>,
 }
 
 impl<T> Receiver<T> {
     #[inline(always)]
-    pub(crate) fn new(inner: futures::channel::oneshot::Receiver<T>) -> Self {
+    pub(crate) fn new(inner: futures_channel::oneshot::Receiver<T>) -> Self {
         Receiver { inner }
     }
 
@@ -43,12 +43,12 @@ impl<T> Future for Receiver<T> {
 
 #[derive(Debug)]
 pub struct Sender<T> {
-    inner: futures::channel::oneshot::Sender<T>,
+    inner: futures_channel::oneshot::Sender<T>,
 }
 
 impl<T> Sender<T> {
     #[inline(always)]
-    pub(crate) fn new(inner: futures::channel::oneshot::Sender<T>) -> Self {
+    pub(crate) fn new(inner: futures_channel::oneshot::Sender<T>) -> Self {
         Sender { inner }
     }
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -20,7 +20,10 @@ notify = "4.0.15"
 distill-downstream-lmdb-rkv = "0.11.0-windows-fix"
 rayon = { version = "1.3", optional = true }
 log = { version = "0.4", features = ["serde", "std"] }
-futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-io = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await", "async-await-macro"] }
+futures-channel = { version = "0.3", default-features = false, features = ["std"] }
 event-listener = { version = "2.4.0" }
 serde = "1"
 serde_derive = "1.0"

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -18,7 +18,7 @@ use distill_schema::{
     parse_artifact_metadata, parse_db_asset_ref,
     service::asset_hub,
 };
-use futures::{AsyncReadExt, TryFutureExt};
+use futures_util::{AsyncReadExt, TryFutureExt};
 
 use crate::{
     artifact_cache::ArtifactCache,

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -14,7 +14,7 @@ use distill_core::distill_signal;
 use distill_importer::{BoxedImporter, ImporterContext};
 use distill_schema::data;
 use file_asset_source::FileAssetSource;
-use futures::future::FutureExt;
+use futures_util::future::FutureExt;
 use std::rc::Rc;
 
 use crate::{
@@ -252,11 +252,11 @@ impl AssetDaemon {
 
         let rx_fuse = rx.fuse();
 
-        futures::pin_mut!(service_handle, tracker_handle, asset_source_handle, rx_fuse);
+        futures_util::pin_mut!(service_handle, tracker_handle, asset_source_handle, rx_fuse);
 
         log::info!("Starting Daemon Loop");
         loop {
-            futures::select! {
+            futures_util::select! {
                 _done = &mut service_handle => panic!("ServiceHandle panicked"),
                 _done = &mut tracker_handle => panic!("FileTracker panicked"),
                 _done = &mut asset_source_handle => panic!("AssetSource panicked"),

--- a/daemon/src/file_asset_source.rs
+++ b/daemon/src/file_asset_source.rs
@@ -19,7 +19,8 @@ use distill_schema::{
     data::{self, path_refs, source_metadata},
     parse_db_metadata,
 };
-use futures::{channel::mpsc::unbounded, lock::Mutex, stream::StreamExt};
+use futures_channel::mpsc::unbounded;
+use futures_util::{lock::Mutex, stream::StreamExt};
 use log::{debug, error, info};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;

--- a/daemon/src/file_tracker.rs
+++ b/daemon/src/file_tracker.rs
@@ -17,8 +17,8 @@ use std::{
 use distill_core::utils::{self, canonicalize_path};
 use distill_schema::data::{self, dirty_file_info, rename_file_event, source_file_info, FileType};
 use event_listener::Event;
-use futures::{
-    channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+use futures_channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures_util::{
     lock::Mutex,
     stream::StreamExt,
     FutureExt,
@@ -705,17 +705,17 @@ impl FileTracker {
         let listener_rx = listener_rx_guard.get_mut().fuse();
         let watcher_rx = watcher_rx.fuse();
 
-        futures::pin_mut!(watcher_rx, listener_rx, stopping);
+        futures_util::pin_mut!(watcher_rx, listener_rx, stopping);
 
         let mut dirty = false;
 
         #[allow(unused_mut)]
         loop {
-            let delay = futures::FutureExt::fuse(async_io::Timer::after(Duration::from_millis(40)));
+            let delay = futures_util::future::FutureExt::fuse(async_io::Timer::after(Duration::from_millis(40)));
 
-            futures::pin_mut!(delay);
+            futures_util::pin_mut!(delay);
 
-            futures::select! {
+            futures_util::select! {
                 new_listener = listener_rx.next() => listeners.register(new_listener),
                 _ = delay => {
                     if dirty {

--- a/daemon/src/source_pair_import.rs
+++ b/daemon/src/source_pair_import.rs
@@ -14,7 +14,8 @@ use distill_importer::{
     SourceMetadata as ImporterSourceMetadata, SOURCEMETADATA_VERSION,
 };
 use distill_schema::data;
-use futures::future::{BoxFuture, Future};
+use futures_core::future::BoxFuture;
+use std::future::Future;
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +26,7 @@ use crate::{
     file_tracker::FileState,
     watcher::file_metadata,
 };
-use futures::AsyncReadExt;
+use futures_util::AsyncReadExt;
 
 pub type SourceMetadata = ImporterSourceMetadata<Box<dyn SerdeObj>, Box<dyn SerdeObj>>;
 
@@ -596,7 +597,7 @@ impl<'a> SourcePairImport<'a> {
                 let mut f = std::fs::File::open(source)?;
                 let mut contents = vec![];
                 f.read_to_end(&mut contents)?;
-                let mut cursor = futures::io::Cursor::new(contents);
+                let mut cursor = futures_util::io::Cursor::new(contents);
 
                 importer
                     .import_boxed(

--- a/daemon/src/watcher.rs
+++ b/daemon/src/watcher.rs
@@ -10,7 +10,7 @@ use distill_core::utils::canonicalize_path;
 use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 
 use crate::error::{Error, Result};
-use futures::channel::mpsc::UnboundedSender;
+use futures_channel::mpsc::UnboundedSender;
 
 /// The purpose of DirWatcher is to provide enough information to
 /// determine which files may be candidates for going through the asset import process.

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -15,7 +15,9 @@ serde = "1"
 erased-serde = "0.3"
 ron = { version = "0.6.4", optional = true }
 typetag = { version = "0.1", optional = true }
-futures = "0.3"
+futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-io = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 log = { version = "0.4", features = ["serde"] }
 
 [features]

--- a/importer/src/boxed_importer.rs
+++ b/importer/src/boxed_importer.rs
@@ -1,6 +1,7 @@
 use distill_core::TypeUuidDynamic;
 use erased_serde::Deserializer;
-use futures::{future::BoxFuture, AsyncRead, AsyncWrite};
+use futures_core::future::BoxFuture;
+use futures_io::{AsyncRead, AsyncWrite};
 use serde::{Deserialize, Serialize};
 
 use crate::{error::Result, AsyncImporter, ExportAsset, ImportOp, ImporterValue, SerdeObj};

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -14,7 +14,9 @@ pub use distill_core::{
 use distill_core::{AssetRef, AssetUuid};
 #[cfg(feature = "serde_importers")]
 pub use distill_serde_importable_derive::*;
-use futures::{future::BoxFuture, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use futures_core::future::BoxFuture;
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_util::{AsyncReadExt, AsyncWriteExt};
 pub use serde;
 use serde::Serialize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,9 @@ mod tests {
         },
         LoadHandle, Loader,
     };
-    use futures::{future::BoxFuture, io::AsyncReadExt, AsyncRead};
+    use futures_core::future::BoxFuture;
+    use futures_io::AsyncRead;
+    use futures_util::io::AsyncReadExt;
     use serde::{Deserialize, Serialize};
     use serial_test::serial;
     use uuid::Uuid;


### PR DESCRIPTION
Just a draft, not sure if we should do this or not. This mostly trades futures for futures_util. We might be able to move to using futures_lite or reduce features enabled with futures_util. So I wouldn't see this as a final goal, but an initial step towards a trimmer build. (This builds on the tokio removal).