### PR TITLE
`&mut self` access in `AssetStorage`

### DIFF
--- a/daemon/src/source_pair_import.rs
+++ b/daemon/src/source_pair_import.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     fs,
     hash::{Hash, Hasher},
-    io::{BufRead, Read, Write},
+    io::{BufRead, Write},
     path::{Path, PathBuf},
     time::Instant,
 };

--- a/examples/handle_integration/src/storage.rs
+++ b/examples/handle_integration/src/storage.rs
@@ -208,7 +208,7 @@ impl<A: for<'a> serde::Deserialize<'a> + 'static + TypeUuid> TypedStorage for St
 // Untyped implementation of AssetStorage that finds the asset_type's storage and forwards the call
 impl AssetStorage for GenericAssetStorage {
     fn update_asset(
-        &self,
+        &mut self,
         loader_info: &dyn LoaderInfoProvider,
         asset_type_id: &AssetTypeId,
         data: Vec<u8>,
@@ -224,7 +224,7 @@ impl AssetStorage for GenericAssetStorage {
     }
 
     fn commit_asset_version(
-        &self,
+        &mut self,
         asset_type: &AssetTypeId,
         load_handle: LoadHandle,
         version: u32,
@@ -236,7 +236,7 @@ impl AssetStorage for GenericAssetStorage {
             .commit_asset_version(load_handle, version)
     }
 
-    fn free(&self, asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32) {
+    fn free(&mut self, asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32) {
         self.storage
             .borrow_mut()
             .get_mut(asset_type_id)

--- a/loader/src/loader.rs
+++ b/loader/src/loader.rs
@@ -326,7 +326,7 @@ impl LoaderState {
         handle
     }
 
-    fn process_load_states(&self, asset_storage: &dyn AssetStorage) {
+    fn process_load_states(&self, asset_storage: &mut dyn AssetStorage) {
         let mut to_remove = Vec::new();
         let keys: Vec<_> = self.load_states.iter().map(|x| *x.key()).collect();
 
@@ -639,7 +639,7 @@ impl LoaderState {
         }
     }
 
-    fn process_data_requests(&self, storage: &dyn AssetStorage, io: &mut dyn LoaderIO) {
+    fn process_data_requests(&self, storage: &mut dyn AssetStorage, io: &mut dyn LoaderIO) {
         while let Ok(response) = self.responses.data_rx.try_recv() {
             let result = response.0;
             let handle = response.1;
@@ -730,7 +730,7 @@ impl LoaderState {
         }
     }
 
-    fn process_load_ops(&self, asset_storage: &dyn AssetStorage) {
+    fn process_load_ops(&self, asset_storage: &mut dyn AssetStorage) {
         while let Ok(op) = self.op_rx.try_recv() {
             match op {
                 HandleOp::Error(_handle, _version, err) => {
@@ -792,7 +792,7 @@ impl LoaderState {
     }
 
     /// Checks for changed assets that need to be reloaded or unloaded
-    fn process_asset_changes(&mut self, asset_storage: &dyn AssetStorage) {
+    fn process_asset_changes(&mut self, asset_storage: &mut dyn AssetStorage) {
         if self.pending_reloads.is_empty() {
             // if we have no pending hot reloads, poll for new changes
             let mut changes = HashSet::new();
@@ -1147,7 +1147,7 @@ impl Loader {
     /// * `asset_storage`: Storage for all assets of all asset types.
     pub fn process(
         &mut self,
-        asset_storage: &dyn AssetStorage,
+        asset_storage: &mut dyn AssetStorage,
         resolver: &dyn IndirectionResolver,
     ) -> Result<()> {
         self.io.tick(&mut self.data);
@@ -1193,7 +1193,7 @@ fn commit_asset(
     handle: LoadHandle,
     load: &mut AssetLoad,
     version: u32,
-    asset_storage: &dyn AssetStorage,
+    asset_storage: &mut dyn AssetStorage,
 ) {
     let version_load = load
         .versions

--- a/loader/src/storage.rs
+++ b/loader/src/storage.rs
@@ -109,7 +109,7 @@ pub trait AssetStorage {
     /// * `load_op`: Allows the loading implementation to signal when loading is done / errors.
     /// * `version`: Runtime load version of this asset, increments each time the asset is updated.
     fn update_asset(
-        &self,
+        &mut self,
         loader_info: &dyn LoaderInfoProvider,
         asset_type_id: &AssetTypeId,
         data: Vec<u8>,
@@ -125,7 +125,12 @@ pub trait AssetStorage {
     /// * `asset_type_id`: UUID of the asset type.
     /// * `load_handle`: ID allocated by [`Loader`](crate::loader::Loader) to track loading of a particular asset.
     /// * `version`: Runtime load version of this asset, increments each time the asset is updated.
-    fn commit_asset_version(&self, asset_type: &AssetTypeId, load_handle: LoadHandle, version: u32);
+    fn commit_asset_version(
+        &mut self,
+        asset_type: &AssetTypeId,
+        load_handle: LoadHandle,
+        version: u32,
+    );
 
     /// Frees the asset identified by the load handle.
     ///
@@ -133,7 +138,7 @@ pub trait AssetStorage {
     ///
     /// * `asset_type_id`: UUID of the asset type.
     /// * `load_handle`: ID allocated by [`Loader`](crate::loader::Loader) to track loading of a particular asset.
-    fn free(&self, asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32);
+    fn free(&mut self, asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32);
 }
 
 /// Asset loading status.


### PR DESCRIPTION
In my bevy-distill integration it was annoying to implement the `AssetStorage` because I needed to wrap the storage in a Mutex, even though I already had mutable access and `Loader::process` could work with `&mut dyn AssetStorage` the same.
Also I feel like `update_asset`, `commit_asset` and `free` fundamentally *are* mutating operations, so `&mut self` makes more sense to me.

This also removes some `RefCell`s in the examples.

It may be that I missed the reason for the `&self` access and this change can't be done, in that case please let me know why! :slightly_smiling_face: 