### PR TITLE
RpcIO on wasm

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -40,7 +40,7 @@ async-lock = { version = "2.1" }
 async-channel = { version = "1.4" }
 bevy_tasks = "0.5.0"
 
-async-tungstenite = "0.15"
+async-tungstenite =  { version = "0.15", optional = true }
 
 [dev-dependencies]
 tempfile = "3.2.0"
@@ -51,3 +51,4 @@ pin-project-lite = "0.2.6"
 [features]
 parallel_hash = ["rayon"]
 pretty_log = ["chrono", "fern"]
+ws = ["async-tungstenite"]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -40,6 +40,8 @@ async-lock = { version = "2.1" }
 async-channel = { version = "1.4" }
 bevy_tasks = "0.5.0"
 
+async-tungstenite = "0.15"
+
 [dev-dependencies]
 tempfile = "3.2.0"
 futures-test = "0.3.15"

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -27,7 +27,6 @@ use crate::{
     error::Error,
     file_asset_source::FileAssetSource,
     file_tracker::FileTracker,
-    websocket_async_io::accept_websocket_stream,
 };
 
 // crate::Error has `impl From<crate::Error> for capnp::Error`
@@ -628,7 +627,9 @@ impl AssetHubService {
         result.expect("Failed to run tcp listener");
     }
 
+    #[cfg(feature = "ws")]
     pub async fn run_on_websocket(&self, addr: std::net::SocketAddr) -> Result<()> {
+        use crate::websocket_async_io::accept_websocket_stream;
         use async_tungstenite::tungstenite;
 
         let listener = async_net::TcpListener::bind(addr).await?;

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -18,7 +18,7 @@ use distill_schema::{
     parse_artifact_metadata, parse_db_asset_ref,
     service::asset_hub,
 };
-use futures::{AsyncReadExt, TryFutureExt};
+use futures::AsyncReadExt;
 
 use crate::{
     artifact_cache::ArtifactCache,
@@ -27,11 +27,12 @@ use crate::{
     error::Error,
     file_asset_source::FileAssetSource,
     file_tracker::FileTracker,
+    websocket_async_io::accept_websocket_stream,
 };
 
 // crate::Error has `impl From<crate::Error> for capnp::Error`
 type Promise<T> = capnp::capability::Promise<T, capnp::Error>;
-type Result<T> = std::result::Result<T, Error>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 struct ServiceContext {
     hub: Arc<AssetHub>,
@@ -594,7 +595,7 @@ impl AssetHubService {
                 let ctx = self.ctx.clone();
 
                 std::thread::spawn(|| {
-                    log::info!("async_net::TcpListener accepted");
+                    log::debug!("async_net::TcpListener accepted");
 
                     stream.set_nodelay(true).unwrap();
                     let (reader, writer) = stream.split();
@@ -615,7 +616,7 @@ impl AssetHubService {
                     );
 
                     let rpc_system = RpcSystem::new(Box::new(network), Some(hub_impl.client));
-                    async_io::block_on(local.run(rpc_system.map_err(|_| ()))).unwrap();
+                    async_io::block_on(local.run(rpc_system)).unwrap();
                 });
             }
         }
@@ -625,6 +626,53 @@ impl AssetHubService {
         // NOTE(kabergstrom): It also seems to happen when the main thread
         // is aborted and this is run on a background thread
         result.expect("Failed to run tcp listener");
+    }
+
+    pub async fn run_on_websocket(&self, addr: std::net::SocketAddr) -> Result<()> {
+        use async_tungstenite::tungstenite;
+
+        let listener = async_net::TcpListener::bind(addr).await?;
+
+        loop {
+            let (stream, _) = listener.accept().await?;
+            let ctx = Arc::clone(&self.ctx);
+
+            let (reader, writer) = match accept_websocket_stream(stream).await {
+                Ok(res) => res,
+                Err(tungstenite::Error::ConnectionClosed) => continue,
+                Err(err) => {
+                    log::error!("failed to accept websocket connection: {}", err);
+                    continue;
+                }
+            };
+
+            std::thread::spawn(|| {
+                log::debug!("websocket connection accepted");
+
+                let local = Rc::new(async_executor::LocalExecutor::new());
+                let service_impl = AssetHubImpl {
+                    ctx,
+                    local: local.clone(),
+                };
+
+                let hub_impl: asset_hub::Client = capnp_rpc::new_client(service_impl);
+
+                let network = twoparty::VatNetwork::new(
+                    reader,
+                    writer,
+                    rpc_twoparty_capnp::Side::Server,
+                    Default::default(),
+                );
+
+                let rpc_system = RpcSystem::new(Box::new(network), Some(hub_impl.client));
+                match async_io::block_on(local.run(rpc_system)) {
+                    Ok(()) => {}
+                    Err(e) if e.description == tungstenite::Error::ConnectionClosed.to_string() => {
+                    }
+                    Err(other) => panic!("{}", other),
+                }
+            });
+        }
     }
 }
 

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -4,6 +4,7 @@ use std::{fmt, io, path::PathBuf, str};
 pub enum Error {
     Notify(notify::Error),
     IO(io::Error),
+    Websocket(async_tungstenite::tungstenite::Error),
     RescanRequired,
     Lmdb(lmdb::Error),
     Capnp(capnp::Error),
@@ -29,6 +30,7 @@ impl std::error::Error for Error {
         match *self {
             Error::Notify(ref e) => Some(e),
             Error::IO(ref e) => Some(e),
+            Error::Websocket(ref e) => Some(e),
             Error::RescanRequired => None,
             Error::Lmdb(ref e) => Some(e),
             Error::Capnp(ref e) => Some(e),
@@ -53,6 +55,7 @@ impl fmt::Display for Error {
         match *self {
             Error::Notify(ref e) => e.fmt(f),
             Error::IO(ref e) => e.fmt(f),
+            Error::Websocket(ref e) => e.fmt(f),
             Error::RescanRequired => write!(f, "{}", self),
             Error::Lmdb(ref e) => e.fmt(f),
             Error::Capnp(ref e) => e.fmt(f),
@@ -83,6 +86,11 @@ impl From<notify::Error> for Error {
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error::IO(err)
+    }
+}
+impl From<async_tungstenite::tungstenite::Error> for Error {
+    fn from(err: async_tungstenite::tungstenite::Error) -> Error {
+        Error::Websocket(err)
     }
 }
 impl From<lmdb::Error> for Error {

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -4,6 +4,7 @@ use std::{fmt, io, path::PathBuf, str};
 pub enum Error {
     Notify(notify::Error),
     IO(io::Error),
+    #[cfg(feature = "ws")]
     Websocket(async_tungstenite::tungstenite::Error),
     RescanRequired,
     Lmdb(lmdb::Error),
@@ -30,6 +31,7 @@ impl std::error::Error for Error {
         match *self {
             Error::Notify(ref e) => Some(e),
             Error::IO(ref e) => Some(e),
+            #[cfg(feature = "ws")]
             Error::Websocket(ref e) => Some(e),
             Error::RescanRequired => None,
             Error::Lmdb(ref e) => Some(e),
@@ -55,6 +57,7 @@ impl fmt::Display for Error {
         match *self {
             Error::Notify(ref e) => e.fmt(f),
             Error::IO(ref e) => e.fmt(f),
+            #[cfg(feature = "ws")]
             Error::Websocket(ref e) => e.fmt(f),
             Error::RescanRequired => write!(f, "{}", self),
             Error::Lmdb(ref e) => e.fmt(f),
@@ -88,6 +91,7 @@ impl From<io::Error> for Error {
         Error::IO(err)
     }
 }
+#[cfg(feature = "ws")]
 impl From<async_tungstenite::tungstenite::Error> for Error {
     fn from(err: async_tungstenite::tungstenite::Error) -> Error {
         Error::Websocket(err)

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -22,6 +22,7 @@ mod file_tracker;
 mod serialized_asset;
 mod source_pair_import;
 mod watcher;
+mod websocket_async_io;
 
 // This module is only used from test code
 #[cfg(test)]

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -22,6 +22,7 @@ mod file_tracker;
 mod serialized_asset;
 mod source_pair_import;
 mod watcher;
+#[cfg(feature = "ws")]
 mod websocket_async_io;
 
 // This module is only used from test code

--- a/daemon/src/websocket_async_io.rs
+++ b/daemon/src/websocket_async_io.rs
@@ -1,0 +1,107 @@
+//! `AsyncRead` and `AsyncWrite` implementations on top of `tungestenite`-websockets
+
+use std::io;
+
+use async_tungstenite::tungstenite::{Error, Message};
+use futures::{future, Sink};
+use futures::{AsyncRead, AsyncWrite, SinkExt, StreamExt, TryStreamExt};
+use std::{pin::Pin, task::Poll};
+
+pub async fn accept_websocket_stream<S>(
+    stream: S,
+) -> Result<(impl AsyncRead, impl AsyncWrite), Error>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let ws_stream = async_tungstenite::accept_async(stream).await?;
+
+    let (sink, stream) = ws_stream.split();
+
+    let stream = stream
+        .and_then(|message| async {
+            match message {
+                Message::Binary(bytes) => Ok(bytes),
+                Message::Close(_) => Err(Error::ConnectionClosed),
+                other => Err(Error::Io(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "tungstenite-async-io can only handle binary messages, got {:?}",
+                        other
+                    ),
+                ))),
+            }
+        })
+        .take_while(|res| match res {
+            Err(Error::ConnectionClosed) => future::ready(false),
+            _ => future::ready(true),
+        })
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
+
+    let stream = Box::pin(stream);
+    let async_read = stream.into_async_read();
+
+    let sink = sink.with(|data: Vec<u8>| async { Ok::<_, Error>(Message::Binary(data)) });
+    let sink = Box::pin(sink);
+    let async_write = IntoAsyncWrite::new(sink);
+
+    Ok((async_read, async_write))
+}
+
+struct IntoAsyncWrite<S: Sink<Vec<u8>> + Unpin> {
+    sink: S,
+    buffer: Vec<u8>,
+}
+
+impl<S: Sink<Vec<u8>> + Unpin> IntoAsyncWrite<S> {
+    pub fn new(sink: S) -> Self {
+        IntoAsyncWrite {
+            sink,
+            buffer: Vec::new(),
+        }
+    }
+}
+
+impl<S> AsyncWrite for IntoAsyncWrite<S>
+where
+    S: Sink<Vec<u8>> + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<io::Result<usize>> {
+        self.get_mut().buffer.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        let map_err = |e| io::Error::new(io::ErrorKind::Other, e);
+
+        let sink = Pin::new(&mut self.sink);
+        match sink.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(e)) => return Poll::Ready(Err(map_err(e))),
+            Poll::Pending => return Poll::Pending,
+        }
+
+        let buffer = std::mem::take(&mut self.buffer);
+        let sink = Pin::new(&mut self.sink);
+        sink.start_send(buffer).map_err(map_err)?;
+
+        let sink = Pin::new(&mut self.sink);
+        sink.poll_flush(cx).map_err(map_err)
+    }
+
+    fn poll_close(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        let map_err = |e| io::Error::new(io::ErrorKind::Other, e);
+
+        Pin::new(&mut self.sink).poll_close(cx).map_err(map_err)
+    }
+}

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -21,17 +21,17 @@ dashmap = "4.0.1"
 serde = { version = "1", features = ["derive"], optional = true }
 uuid = { version = "0.8.2", optional = true }
 thread_local = { version = "1.0", optional = true }
-async-io = { version = "1.4.1", optional = true }
 async-executor = { version = "1.4.1", optional = true }
-async-net = { version = "1.6.0", optional = true }
 bevy_tasks = { version = "0.5.0", optional = true }
 pin-project-lite = "0.2.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memmap = { version = "0.7", optional = true }
+async-net = { version = "1.6.0", optional = true }
 instant = { version = "0.1" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+websocket-async-io = { version = "1.0", optional = true }
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 
 [features]
@@ -53,9 +53,9 @@ rpc_io = [
     "capnp-rpc",
     "futures-util",
     "invalidate_path",
-    "async-io",
     "async-executor",
-    "async-net"
+    "async-net",
+    "websocket-async-io"
 ]
 invalidate_path = ["distill-core/path_utils"]
 handle = ["serde", "uuid"]


### PR DESCRIPTION
- the first commit changes the daemon to run the asset hub service both on tcp and over websockets. It uses `async-tungstenite` and a bit of adater code to get `AsyncRead` and `AsyncWrite` types you can plug into the `VatNetwork`
- the second command changes `RpcIO` to be configurable whether you want to connect via ws or tcp.
The public facing change is that `RpcIO::new(connect_string: String)` turns into `RpcIO::new(connection_type: ConnectionType)`
with
```rust
#[derive(Debug, Copy, Clone)]
pub enum RpcConnectionType {
    Websocket(String),
    TCP(String),
}
```
`TCP` on wasm and `Websocket` on native currently panic, the latter could be implemented if deemed useful.