### PR TITLE
Increase traversal limit in capnp_db

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -66,9 +66,7 @@ pub async fn create_context(
         reader,
         writer,
         rpc_twoparty_capnp::Side::Client,
-        *ReaderOptions::new()
-            .nesting_limit(64)
-            .traversal_limit_in_words(Some(256 * 1024 * 1024)),
+        *distill_schema::default_capnp_reader_options(),
     ));
 
     let mut rpc_system = RpcSystem::new(rpc_network, None);

--- a/daemon/src/capnp_db.rs
+++ b/daemon/src/capnp_db.rs
@@ -81,7 +81,7 @@ impl<'cursor, 'txn> Iterator for Iter<'cursor, 'txn> {
                 let mut slice = value_bytes;
                 let value_msg = capnp::serialize::read_message_from_flat_slice(
                     &mut slice,
-                    capnp::message::ReaderOptions::default(),
+                    distill_schema::default_capnp_reader_options(),
                 );
                 Some((key_bytes, value_msg))
             }
@@ -110,7 +110,7 @@ pub trait DBTransaction<'a, T: lmdb::Transaction + 'a>: Sized {
         if let Ok(mut slice) = get_result {
             let msg = capnp::serialize::read_message_from_flat_slice(
                 &mut slice,
-                capnp::message::ReaderOptions::default(),
+                distill_schema::default_capnp_reader_options(),
             )?
             .into_typed::<V>();
             Ok(Some(msg))
@@ -139,7 +139,7 @@ pub trait DBTransaction<'a, T: lmdb::Transaction + 'a>: Sized {
         if let Ok(mut slice) = get_result {
             let msg = capnp::serialize::read_message_from_flat_slice(
                 &mut slice,
-                capnp::message::ReaderOptions::default(),
+                distill_schema::default_capnp_reader_options(),
             )?
             .into_typed::<V>();
             Ok(Some(msg))

--- a/loader/src/packfile_io.rs
+++ b/loader/src/packfile_io.rs
@@ -109,9 +109,10 @@ impl Drop for PackfileMessageReaderBuffer {
 fn capnp_reader_from_slice<'a>(
     mut slice: &mut &'a [u8],
 ) -> Result<capnp::message::Reader<SliceSegments<'a>>, capnp::Error> {
-    let mut options = capnp::message::ReaderOptions::new();
-    options.traversal_limit_in_words(Some(1 << 31));
-    capnp::serialize::read_message_from_flat_slice(&mut slice, options)
+    capnp::serialize::read_message_from_flat_slice(
+        &mut slice,
+        distill_schema::default_capnp_reader_options_unbounded(),
+    )
 }
 
 struct PackfileReaderInner {

--- a/loader/src/rpc_io.rs
+++ b/loader/src/rpc_io.rs
@@ -1,6 +1,5 @@
 use std::{error::Error, path::PathBuf, sync::Mutex};
 
-use capnp::message::ReaderOptions;
 use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use distill_core::{distill_signal, utils, AssetMetadata, AssetUuid};
@@ -133,9 +132,7 @@ impl RpcRuntime {
                         reader,
                         writer,
                         rpc_twoparty_capnp::Side::Client,
-                        *ReaderOptions::new()
-                            .nesting_limit(64)
-                            .traversal_limit_in_words(Some(256 * 1024 * 1024)),
+                        distill_schema::default_capnp_reader_options(),
                     ));
 
                     let mut rpc_system = RpcSystem::new(rpc_network, None);

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -8,7 +8,25 @@
 )]
 
 mod schemas;
+use capnp::message::ReaderOptions;
 use std::path::PathBuf;
+
+pub const DEFAULT_CAPNP_TRAVERSAL_LIMIT_IN_WORDS: Option<usize> = Some(256 * 1024 * 1024);
+pub const DEFAULT_CAPNP_NESTING_LIMIT: i32 = 64;
+
+// Recommended default settings, including for use over network sockets
+pub fn default_capnp_reader_options() -> ReaderOptions {
+    *ReaderOptions::new()
+        .nesting_limit(DEFAULT_CAPNP_NESTING_LIMIT)
+        .traversal_limit_in_words(DEFAULT_CAPNP_TRAVERSAL_LIMIT_IN_WORDS)
+}
+
+// Used in trusted cases like reading a file from disk
+pub fn default_capnp_reader_options_unbounded() -> ReaderOptions {
+    *ReaderOptions::new()
+        .nesting_limit(DEFAULT_CAPNP_NESTING_LIMIT)
+        .traversal_limit_in_words(Some(1 << 31))
+}
 
 use distill_core::{utils::make_array, ArtifactId, ArtifactMetadata, AssetMetadata, AssetRef};
 pub use schemas::{data_capnp, pack_capnp, service_capnp};


### PR DESCRIPTION
Increase traversal limit to support larger assets, consolidate usages of ReaderOptions to a single place.