### PR TITLE
Allow importers to override default options on initial import

### DIFF
--- a/daemon/src/file_asset_source.rs
+++ b/daemon/src/file_asset_source.rs
@@ -12,7 +12,7 @@ use distill_core::{
     ArtifactId, AssetRef, AssetTypeId, AssetUuid, CompressionType,
 };
 use distill_importer::{
-    ArtifactMetadata, AssetMetadata, BoxedImporter, ImporterContext, SerializedAsset,
+    ArtifactMetadata, AssetMetadata, BoxedImporter, ImportSource, ImporterContext, SerializedAsset,
 };
 use distill_schema::{
     build_asset_metadata,
@@ -687,7 +687,7 @@ impl FileAssetSource {
         let mut import = SourcePairImport::new(path.clone());
         import.set_importer_from_map(&self.importers);
         import.set_importer_contexts(&self.importer_contexts);
-        import.generate_source_metadata(&cache);
+        import.generate_source_metadata(&cache, ImportSource::File(&path));
         import.hash_source();
 
         log::trace!("Importing source for {:?}", id);
@@ -1005,7 +1005,7 @@ impl FileAssetSource {
                 if !import.set_importer_from_map(&self.importers) {
                     log::warn!("failed to set importer from map for path {:?} when updating path ref dependencies", path_ref_source);
                 } else {
-                    import.generate_source_metadata(&cache);
+                    import.generate_source_metadata(&cache, ImportSource::File(&path.clone()));
                     import
                         .get_result_metadata_from_cache(&cache)
                         .expect("error fetching import result metadata from cache");
@@ -1201,7 +1201,7 @@ impl FileAssetSource {
                                 .expect("capnp: Failed to get importer type");
 
                             importer_version != importer.version()
-                                || options_type != importer.default_options().uuid()
+                                || options_type != importer.options_type_uuid()
                                 || state_type != importer.default_state().uuid()
                                 || importer_type != importer.uuid()
                         }


### PR DESCRIPTION
The motivating problem for this PR is that I have hundreds of normal maps and metalness/roughness maps. They were being imported incorrectly and I'd like to use the file name as a heuristic for how to handle them by default. Otherwise I would need to hand-edit hundreds of meta files. Long term, the ideal solution would be to have an editor that can be used to quickly fix the images.

Here is some sample code that demonstrates the feature, it's added to the image importer:

```rust
    fn default_options(
        &self,
        import_source: ImportSource,
    ) -> Option<Self::Options> {
        match import_source {
            ImportSource::File(path) => {
                for rule in &self.1.rules {
                    if let Some(options) = rule.try_apply(path) {
                        return Some(ImageImporterOptions {
                            mip_generation: options.mip_generation,
                            data_format: options.data_format,
                            color_space: options.color_space,
                        });
                    }
                }
            }
        }

        return Some(ImageImporterOptions {
            mip_generation: self.1.default.mip_generation,
            data_format: self.1.default.data_format,
            color_space: self.1.default.color_space,
        });
    }
```