### PR TITLE
Reduce cargo-deny vulnerabilities from deny to warn

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,8 @@
+[advisories]
+# Reduced from deny to warn, these fail our CI and are generally not
+# actionable within this project.
+vulnerability = "warn"
+
 [licenses]
 allow = ["MIT", "Apache-2.0"]
 copyleft = "deny"


### PR DESCRIPTION
Vulnerability warnings are failing CI and they generally aren't actionable in this project.